### PR TITLE
Bump js package version to 3.19.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faire/protobuf",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "description": "Protocol Buffers for JavaScript",
   "main": "google-protobuf.js",
   "files": [


### PR DESCRIPTION
The package has been published here: 

<img width="461" alt="image" src="https://user-images.githubusercontent.com/7275468/235483866-cb11ed54-f11a-4a4e-9531-fb0f62bf83f6.png">
